### PR TITLE
feat: improve job submission and scaling options in cluster submission and runners

### DIFF
--- a/annotation_processing_utils/cli/runners.py
+++ b/annotation_processing_utils/cli/runners.py
@@ -80,6 +80,12 @@ def run_inference():
         help="The shape of the roi - in world units -  as a comma separated list",
         required=True,
     )
+    parser.add_argument(
+        "--input_shape_scaling_factor",
+        type=float,
+        help="Factor by which to scale the input shape and output size (default: 2)",
+        default=2,
+    )
 
     args = parser.parse_args()
 
@@ -96,6 +102,7 @@ def run_inference():
         args.invert,
         args.inference_path,
         roi,
+        args.input_shape_scaling_factor,
     )
 
 
@@ -118,7 +125,7 @@ def run_mws():
     )
     parser.add_argument(
         "--minimum_volume_nm_3",
-        type=int,
+        type=float,
         help="Minimum volume in nm^3",
         required=False,
         default=0,
@@ -161,10 +168,22 @@ def run_mws():
         help="Mask if applicable (where a 0 indicates a region to ignore)",
         required=False,
     )
+    parser.add_argument(
+        "--chunk_shape",
+        default=None,
+        type=str,
+        help="Chunk shape for processing as comma-separated list (e.g., '216,216,216')",
+        required=False,
+    )
     args = parser.parse_args()
     mask_config = args.mask_config
     if mask_config is not None:
         mask_config = json.loads(mask_config)
+
+    chunk_shape = args.chunk_shape
+    if chunk_shape is not None:
+        chunk_shape = [int(x) for x in chunk_shape.split(',')]
+
     mws(
         args.affinities_path,
         args.segmentation_path,
@@ -174,6 +193,7 @@ def run_mws():
         args.lr_biases,
         args.filter_val,
         mask_config,
+        chunk_shape,
     )
 
 

--- a/annotation_processing_utils/postprocess/inference.py
+++ b/annotation_processing_utils/postprocess/inference.py
@@ -28,8 +28,9 @@ import getpass
 
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
-    level=logging.NOTSET,
+    level=logging.INFO,
     datefmt="%Y-%m-%d %H:%M:%S",
+    force=True,
 )
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ def inference(
     invert: bool,
     inference_path: str,
     roi: Roi,
+    input_shape_scaling_factor: int = 1,
 ):
 
     architecture_config = DacapoRunBuilder.create_architecture()
@@ -101,4 +103,5 @@ def inference(
         compute_context=LocalTorch(),
         output_roi=roi,
         write_size=[108 * 8, 108 * 8, 108 * 8, 9],
+        input_shape_scaling_factor=input_shape_scaling_factor,
     )

--- a/annotation_processing_utils/postprocess/mws.py
+++ b/annotation_processing_utils/postprocess/mws.py
@@ -15,6 +15,7 @@ def mws(
     lr_biases,
     filter_val,
     mask_config=None,
+    chunk_shape=None,
 ):
     mutex_watershed_processor = MutexWatershed(
         affinities_path=affinities_path,
@@ -42,6 +43,6 @@ def mws(
         padding_voxels=27,
         do_opening=True,
         delete_tmp=True,
-        chunk_shape=None,
+        chunk_shape=chunk_shape,
     )
     mutex_watershed_processor.get_connected_components()

--- a/annotation_processing_utils/utils/predict_with_write_size.py
+++ b/annotation_processing_utils/utils/predict_with_write_size.py
@@ -13,6 +13,7 @@ import zarr
 
 from typing import Optional
 import logging
+import sys
 
 from annotation_processing_utils.utils.zarr_write_select_channels import (
     ZarrWriteSelectChannels,
@@ -29,21 +30,34 @@ def predict_with_write_size(
     compute_context: ComputeContext = LocalTorch(),
     output_roi: Optional[Roi] = None,
     write_size=None,
+    input_shape_scaling_factor: int = 1,
 ):
     # get the model's input and output size
     input_voxel_size = Coordinate(raw_array.voxel_size)
     output_voxel_size = model.scale(input_voxel_size)
-    input_shape = Coordinate(model.eval_input_shape)
-    input_size = input_voxel_size * input_shape
-    output_size = output_voxel_size * model.compute_output_shape(input_shape)[1]
+
+    # Get base shapes (without scaling)
+    base_input_shape = Coordinate(model.eval_input_shape)
+    base_input_size = input_voxel_size * base_input_shape
+    base_output_size = output_voxel_size * model.compute_output_shape(base_input_shape)[1]
+
+    # Calculate context (should remain constant regardless of scaling)
+    context = (base_input_size - base_output_size) / 2
+
+    # Scale the output size (without context), then add context back
+    scaled_output_size = base_output_size * input_shape_scaling_factor
+    input_size = scaled_output_size + context * 2
+    output_size = scaled_output_size
 
     logger.info(
-        "Predicting with input size %s, output size %s", input_size, output_size
+        "Predicting with input_shape_scaling_factor %d, context %s, input size %s, output size %s",
+        input_shape_scaling_factor, context, input_size, output_size
     )
+    sys.stdout.flush()
+    sys.stderr.flush()
 
     # calculate input and output rois
-
-    context = (input_size - output_size) / 2
+    # (context is already calculated above)
     if output_roi is None:
         input_roi = raw_array.roi
         output_roi = input_roi.grow(-context, -context)
@@ -51,9 +65,18 @@ def predict_with_write_size(
         input_roi = output_roi.grow(context, context)
 
     logger.info("Total input ROI: %s, output ROI: %s", input_roi, output_roi)
+    sys.stdout.flush()
+    sys.stderr.flush()
 
     # prepare prediction dataset
     axes = ["c"] + [axis for axis in raw_array.axes if axis != "c"]
+
+    # Scale write_size if provided, otherwise use default
+    scaled_write_size = None
+    if write_size is not None:
+        # Scale spatial dimensions (first 3 elements), keep channel dimension (last element) unchanged
+        scaled_write_size = [ws * input_shape_scaling_factor for ws in write_size[:3]] + [write_size[3]]
+
     ZarrArray.create_from_array_identifier(
         prediction_array_identifier,
         axes,
@@ -61,7 +84,7 @@ def predict_with_write_size(
         9,
         output_voxel_size,
         np.uint8,
-        write_size=write_size,
+        write_size=scaled_write_size,
     )
 
     # create gunpowder keys


### PR DESCRIPTION
This pull request introduces several improvements and new features to the cluster submission and processing utilities, focusing on resource allocation, argument handling, and scaling support for inference and segmentation tasks. The changes enhance flexibility for users, improve logging and error handling, and allow for more efficient use of compute resources.

**Resource and Argument Handling Improvements:**

* Increased CPU and GPU memory allocation for inference jobs by updating the `bsub_args` to use 8 CPUs and specify GPU memory requirements, and for MWS jobs by increasing CPU allocation from 1 to 2. (`annotation_processing_utils/cli/cluster_submission.py`) [[1]](diffhunk://#diff-590f9b722f4ad51592e79426773e47a367c6f048e1daac697c652c646c16d8f1L129-R134) [[2]](diffhunk://#diff-590f9b722f4ad51592e79426773e47a367c6f048e1daac697c652c646c16d8f1L159-R159)
* Improved handling of flag arguments (e.g., `--invert`) so they are passed correctly without a value, and updated the `bsub_formatter` to omit values for empty-string arguments. (`annotation_processing_utils/cli/cluster_submission.py`) [[1]](diffhunk://#diff-590f9b722f4ad51592e79426773e47a367c6f048e1daac697c652c646c16d8f1L129-R134) [[2]](diffhunk://#diff-590f9b722f4ad51592e79426773e47a367c6f048e1daac697c652c646c16d8f1L268-R274)
* Added support for passing `chunk_shape` as a command-line argument for MWS processing, propagating it through the CLI, submission, and processing functions. (`annotation_processing_utils/cli/cluster_submission.py`, `annotation_processing_utils/cli/runners.py`, `annotation_processing_utils/postprocess/mws.py`) [[1]](diffhunk://#diff-590f9b722f4ad51592e79426773e47a367c6f048e1daac697c652c646c16d8f1R200-R205) [[2]](diffhunk://#diff-e9039357287a569d8a0af0ec49f6ddd924f6a8844530de702e52f3349167b4a6R171-R186) [[3]](diffhunk://#diff-e9039357287a569d8a0af0ec49f6ddd924f6a8844530de702e52f3349167b4a6R196) [[4]](diffhunk://#diff-21bc9c8f911b16faeecc4a03360bc595671b98863f41b8d08103d839d13e3ef9R18) [[5]](diffhunk://#diff-21bc9c8f911b16faeecc4a03360bc595671b98863f41b8d08103d839d13e3ef9L45-R46)

**Inference Scaling and CLI Enhancements:**

* Introduced an `input_shape_scaling_factor` argument for inference, allowing users to scale input and output shapes for predictions. This is supported end-to-end from the CLI (`--input_shape_scaling_factor`) through to the prediction logic, including scaling of `write_size` for output arrays. (`annotation_processing_utils/cli/runners.py`, `annotation_processing_utils/postprocess/inference.py`, `annotation_processing_utils/utils/predict_with_write_size.py`) [[1]](diffhunk://#diff-e9039357287a569d8a0af0ec49f6ddd924f6a8844530de702e52f3349167b4a6R83-R88) [[2]](diffhunk://#diff-e9039357287a569d8a0af0ec49f6ddd924f6a8844530de702e52f3349167b4a6R105) [[3]](diffhunk://#diff-c4895d568599dc7ffaa11649a40fccccecf1d48fab0a8c3f59ecb55ecd791204R52) [[4]](diffhunk://#diff-c4895d568599dc7ffaa11649a40fccccecf1d48fab0a8c3f59ecb55ecd791204R106) [[5]](diffhunk://#diff-31edaada0b8ad1db2878bf09f040259be773f901461aebd8c72005183005832cR33-R87)
* Improved the logic in `predict_with_write_size` to correctly scale both input and output sizes, maintain context, and ensure that write sizes are scaled appropriately for the specified factor. (`annotation_processing_utils/utils/predict_with_write_size.py`)

**Robustness and Logging:**

* Enhanced job submission robustness by adding a timeout and improved error reporting for `subprocess.run` when submitting job arrays, and providing user guidance on timeouts. (`annotation_processing_utils/cli/cluster_submission.py`)
* Changed logging configuration to use `INFO` level and force reconfiguration, ensuring that logs are visible and formatted consistently. (`annotation_processing_utils/postprocess/inference.py`)
* Added explicit flushing of stdout and stderr after logging in prediction routines to ensure timely log output. (`annotation_processing_utils/utils/predict_with_write_size.py`)

**Other Minor Improvements:**

* Changed the type of the `--minimum_volume_nm_3` argument in the MWS CLI from `int` to `float` for more flexibility. (`annotation_processing_utils/cli/runners.py`)
* Removed unused `scale_coordinates` argument from ROI calculation, simplifying the submission logic. (`annotation_processing_utils/cli/cluster_submission.py`)